### PR TITLE
Youtube Tweaks

### DIFF
--- a/core/src/main/java/com/lumination/leadme/DispatchManager.java
+++ b/core/src/main/java/com/lumination/leadme/DispatchManager.java
@@ -166,6 +166,7 @@ public class DispatchManager {
 
     public synchronized void sendActionToSelected(String actionTag, String action, Set<String> selectedPeerIDs) {
         main.setProgressTimer(2000);
+
         if(action.contains(LeadMeMain.LAUNCH_URL) || action.contains(LeadMeMain.LAUNCH_YT)) {
             Log.d(TAG, "sendActionToSelected: ");
             lastEvent = 3;
@@ -189,6 +190,7 @@ public class DispatchManager {
                 action.startsWith(LeadMeMain.STUDENT_NO_INTERNET) ||
                 action.startsWith(LeadMeMain.STUDENT_NO_ACCESSIBILITY) ||
                 action.startsWith(LeadMeMain.STUDENT_OFF_TASK_ALERT) ||
+                action.startsWith(LeadMeMain.STUDENT_FINISH_ADS) ||
                 action.startsWith(LeadMeMain.PING_TAG) ||
                 action.startsWith(LeadMeMain.LAUNCH_SUCCESS) ||
                 action.startsWith(LeadMeMain.STUDENT_NO_XRAY) ||
@@ -387,6 +389,9 @@ public class DispatchManager {
                         Log.d(TAG, "GOT SOMETHING VID RELATED");
                         String[] split = action.split(":");
                         main.getLumiAccessibilityConnector().cueYouTubeAction(split[1]);
+
+                    } else if (action.startsWith(LeadMeMain.STUDENT_FINISH_ADS)) {
+                        main.getWebManager().getYouTubeEmbedPlayer().addPeerReady();
 
                     } else if (action.startsWith(LeadMeMain.LOGOUT_TAG)) {
                         String id = action.split(":")[1];
@@ -638,5 +643,8 @@ public class DispatchManager {
                 main.getNearbyManager().getAllPeerIDs());
     }
 
-
+    protected void alertGuideAdsHaveFinished() {
+        sendActionToSelected(LeadMeMain.ACTION_TAG, LeadMeMain.STUDENT_FINISH_ADS + main.getNearbyManager().getID(),
+                main.getNearbyManager().getAllPeerIDs());
+    }
 }

--- a/core/src/main/java/com/lumination/leadme/FavouritesManager.java
+++ b/core/src/main/java/com/lumination/leadme/FavouritesManager.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FavouritesManager extends BaseAdapter {
 
@@ -316,9 +318,28 @@ public class FavouritesManager extends BaseAdapter {
     //content is URL or packageName
     public void addToFavourites(String content, String title, Drawable icon) {
         Log.d(TAG, "addToFavourites: "+content);
-        if (contentList.contains(content)) {
-            return; //it's already there!
+
+        //get the youtube video id as different links can add the same video
+        String pattern = "(?<=watch\\?v=|/videos/|embed/)[^#&?]*";
+        String youtubeId = content;
+
+        Pattern compiledPattern = Pattern.compile(pattern);
+        Matcher matcher = compiledPattern.matcher(content);
+
+        if(matcher.find()){
+            youtubeId = matcher.group();
         }
+
+        for(int x=0; x < contentList.size(); x++) {
+            if(contentList.get(x).contains(youtubeId)) {
+                Log.d(TAG, "Youtube ID duplicate found");
+                return;
+            };
+        }
+
+//        if (contentList.contains(content)) {
+//            return; //it's already there!
+//        }
 
         //update local/working variables
         int thisIndex = getNextFavIndex();

--- a/core/src/main/java/com/lumination/leadme/LeadMeMain.java
+++ b/core/src/main/java/com/lumination/leadme/LeadMeMain.java
@@ -158,6 +158,8 @@ public class LeadMeMain extends FragmentActivity implements Handler.Callback, Se
     static final String LAUNCH_YT = "LumiYT:::";
     static final String LAUNCH_ACCESS = "LumiLaunchAccess";
 
+    static final String STUDENT_FINISH_ADS = "LumiAdsFinished";
+
     static final String AUTO_INSTALL_FAILED = "LumiAutoInstallFail:";
     static final String AUTO_INSTALL_ATTEMPT = "LumiAutoInstallAttempt:";
     static final String STUDENT_OFF_TASK_ALERT = "LumiOffTask:";

--- a/core/src/main/java/com/lumination/leadme/LumiAccessibilityConnector.java
+++ b/core/src/main/java/com/lumination/leadme/LumiAccessibilityConnector.java
@@ -42,6 +42,7 @@ public class LumiAccessibilityConnector {
     }
 
     public void resetState() {
+        ytManager.adFinished = false;
 //        Log.d(TAG, "resetState: ");
 //        ytManager.resetState();
 //        withinManager.cleanUpVideo();
@@ -151,8 +152,8 @@ public class LumiAccessibilityConnector {
             Log.w(TAG, "Revisiting previous event..." + lastEvent + " " + lastInfo);
             event = lastEvent;
             rootInActiveWindow = lastInfo;
-            lastInfo = null; //we probably don't want to revisit these too many times
-            lastEvent = null; //we probably don't want to revisit these too many times
+            //lastInfo = null; //we probably don't want to revisit these too many times
+            //lastEvent = null; //we probably don't want to revisit these too many times
 
 //       }
 //
@@ -162,7 +163,10 @@ public class LumiAccessibilityConnector {
 
         } else {
             lastEvent = event;
-            lastInfo = rootInActiveWindow;
+            //if null youtube embed gestures stop working
+            if(rootInActiveWindow != null) {
+                lastInfo = rootInActiveWindow;
+            }
         }
 
         if (event == null) {

--- a/core/src/main/java/com/lumination/leadme/YouTubeEmbedPlayer.java
+++ b/core/src/main/java/com/lumination/leadme/YouTubeEmbedPlayer.java
@@ -1,5 +1,6 @@
 package com.lumination.leadme;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.res.ColorStateList;
@@ -7,6 +8,7 @@ import android.net.http.SslError;
 import android.text.format.DateUtils;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.JavascriptInterface;
 import android.webkit.SslErrorHandler;
@@ -63,6 +65,13 @@ public class YouTubeEmbedPlayer {
     private Switch vrModeBtn;
     private boolean firstPlay = true;
 
+    private boolean firstTouch; //track if the guide has started the video
+    private boolean adsFinished; //track if students are still watching ads
+    private ImageView playBtn, pauseBtn;
+
+    //track the peers for ad control
+    int peersAdControl = 0;
+
     private TextView youtubePreviewTitle;
     private Button youtubePreviewPushBtn;
     private TextView repushBtn;
@@ -104,6 +113,8 @@ public class YouTubeEmbedPlayer {
         internetUnavailableMsg.setOnClickListener(v -> loadVideoGuideURL(attemptedURL));
         controllerWebView = videoControllerDialogView.findViewById(R.id.video_stream_webview);
         controllerWebView.setTag("CONTROLLER");
+        playBtn = videoControllerDialogView.findViewById(R.id.play_btn);
+        pauseBtn = videoControllerDialogView.findViewById(R.id.pause_btn);
 
         createPlaybackSettingsPopup();
 
@@ -130,6 +141,7 @@ public class YouTubeEmbedPlayer {
     public void updateState(int state) {
         Log.d(TAG, "[GUIDE] Video state is now: " + state + " // " + currentTime);
         videoCurrentPlayState = state;
+
         //make sure student state is updated too
         if (!init && (state == VIDEO_CUED || state == PLAYING)) {
             String str = extractTime(attemptedURL);
@@ -143,6 +155,12 @@ public class YouTubeEmbedPlayer {
         }
 
         if (state == PLAYING) {
+            //if this is the first state switch guide to buttons
+            if(firstTouch) {
+                firstTouch = false;
+                buttonHighlights(PLAYING);
+            }
+
             main.getDispatcher().sendActionToSelected(LeadMeMain.ACTION_TAG,
                     LeadMeMain.VID_ACTION_TAG + YouTubeAccessibilityManager.CUE_PLAY,
                     main.getNearbyManager().getSelectedPeerIDsOrAll());
@@ -163,6 +181,7 @@ public class YouTubeEmbedPlayer {
 
     boolean pageLoaded = false;
 
+    @SuppressLint("ClickableViewAccessibility")
     private void setupGuideVideoControllerWebClient() {
         controllerWebView.setWebViewClient(new WebViewClient() {
             @Override
@@ -209,6 +228,35 @@ public class YouTubeEmbedPlayer {
                 //Log.d(TAG, "VIDEO GUIDE] Received SSL error: " + error.toString());
             }
         });
+
+        controllerWebView.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                //after ads finish initial play guide uses the buttons
+                if(firstTouch) {
+                    return peerWaitingForAds(); //check if ads have finished
+                }
+
+                return !firstTouch;
+            }
+        });
+    }
+
+    private boolean peerWaitingForAds() {
+        if(peersAdControl != main.getConnectedLearnersAdapter().mData.size()) {
+            main.showWarningDialog("Waiting for Ads","Student devices are still \n" +
+                    "waiting for ads to finish.");
+        }
+
+        return !adsFinished;
+    }
+
+    public void addPeerReady() {
+        peersAdControl += 1;
+        if(peersAdControl == main.getConnectedLearnersAdapter().mData.size()) {
+            adsFinished = true;
+            showToast("Ads finished, all peers ready.");
+        }
     }
 
     private void setupGuideVideoControllerButtons() {
@@ -233,9 +281,10 @@ public class YouTubeEmbedPlayer {
             syncNewStudentsWithCurrentState();
         });
 
-        videoControllerDialogView.findViewById(R.id.video_back_btn).setOnClickListener(v ->
-                hideVideoController()
-        );
+        videoControllerDialogView.findViewById(R.id.video_back_btn).setOnClickListener(v -> {
+            resetControllerState();
+            hideVideoController();
+        });
 
 
         //set up basic controls
@@ -269,6 +318,9 @@ public class YouTubeEmbedPlayer {
                             LeadMeMain.VID_ACTION_TAG + YouTubeAccessibilityManager.CUE_VR_OFF,
                             main.getNearbyManager().getSelectedPeerIDsOrAll());
                 }
+                //keep the guide synced with the students
+                buttonHighlights(PLAYING);
+                activeWebView.loadUrl("javascript:player.playVideo();");
             }
         });
         viewModeToggle = videoControllerDialogView.findViewById(R.id.view_mode_toggle);
@@ -301,28 +353,63 @@ public class YouTubeEmbedPlayer {
             main.getDispatcher().sendActionToSelected(LeadMeMain.ACTION_TAG, LeadMeMain.VID_UNMUTE_TAG, main.getNearbyManager().getSelectedPeerIDsOrAll());
         });
 
-//        videoControllerDialogView.findViewById(R.id.play_btn).setOnClickListener(v -> {
-//            if (videoCurrentDisplayMode == VR_MODE) {
-//                showToast("Cannot play in VR mode. Exit VR mode and try again.");
-//                return;
-//            }
-//            playVideo();
-//            main.getDispatcher().sendActionToSelected(LeadMeMain.ACTION_TAG,
-//                    LeadMeMain.VID_ACTION_TAG + YouTubeAccessibilityManager.CUE_PLAY,
-//                    main.getNearbyManager().getSelectedPeerIDsOrAll());
-//        });
-//
-//        videoControllerDialogView.findViewById(R.id.pause_btn).setOnClickListener(v -> {
-//            if (videoCurrentDisplayMode == VR_MODE) {
-//                showToast("Cannot pause in VR mode. Exit VR mode and try again.");
-//                return;
-//            }
-//            pauseVideo();
-//            main.getDispatcher().sendActionToSelected(LeadMeMain.ACTION_TAG,
-//                    LeadMeMain.VID_ACTION_TAG + YouTubeAccessibilityManager.CUE_PAUSE,
-//                    main.getNearbyManager().getSelectedPeerIDsOrAll());
-//        });
+        videoControllerDialogView.findViewById(R.id.play_btn).setOnClickListener(v -> {
+            if(buttonMessages()) {
+                return;
+            }
 
+            buttonHighlights(PLAYING);
+            //play the video through javascript
+            activeWebView.loadUrl("javascript:player.playVideo();");
+
+            playVideo();
+            main.getDispatcher().sendActionToSelected(LeadMeMain.ACTION_TAG,
+                    LeadMeMain.VID_ACTION_TAG + YouTubeAccessibilityManager.CUE_PLAY,
+                    main.getNearbyManager().getSelectedPeerIDsOrAll());
+        });
+
+        videoControllerDialogView.findViewById(R.id.pause_btn).setOnClickListener(v -> {
+            if(buttonMessages()) {
+                return;
+            }
+
+            buttonHighlights(PAUSED);
+            activeWebView.loadUrl("javascript:player.pauseVideo();");
+
+            pauseVideo();
+            main.getDispatcher().sendActionToSelected(LeadMeMain.ACTION_TAG,
+                    LeadMeMain.VID_ACTION_TAG + YouTubeAccessibilityManager.CUE_PAUSE,
+                    main.getNearbyManager().getSelectedPeerIDsOrAll());
+        });
+
+    }
+
+    private boolean buttonMessages() {
+        boolean stopFunction = false;
+        if(firstTouch) {
+            showToast("Tap the youtube play button to enable controls.");
+            stopFunction = true;
+        }
+
+        if (videoCurrentDisplayMode == VR_MODE) {
+            showToast("Cannot pause in VR mode. Exit VR mode and try again.");
+            stopFunction = true;
+        }
+        return stopFunction;
+    }
+
+    //change video control icon colour
+    private void buttonHighlights(int state) {
+        switch(state) {
+            case 1:
+                playBtn.setImageResource(R.drawable.vid_play_highlight);
+                pauseBtn.setImageResource(R.drawable.vid_pause);
+                break;
+            case 2:
+                playBtn.setImageResource(R.drawable.vid_play);
+                pauseBtn.setImageResource(R.drawable.vid_pause_highlight);
+                break;
+        }
     }
 
     private void syncNewStudentsWithCurrentState() {
@@ -491,6 +578,9 @@ public class YouTubeEmbedPlayer {
         progressBar.setProgress(0);
         playFromTime.setText("00:00");
         elapsedTimeText.setText("00:00");
+        firstTouch = true;
+        adsFinished = false;
+        peersAdControl = 0;
 
         if (vrModeBtn != null && vrModeBtn.isChecked()) {
             vrModeBtn.setChecked(false); //toggle it
@@ -518,7 +608,7 @@ public class YouTubeEmbedPlayer {
             main.hideSystemUI();
         });
 
-        pauseVideo();
+        //pauseVideo(); //do we want to pause here as guide cannot reopen the controller?
         videoControlDialog.dismiss();
     }
 

--- a/core/src/main/res/layout/f__playback_control_youtube.xml
+++ b/core/src/main/res/layout/f__playback_control_youtube.xml
@@ -124,6 +124,67 @@
                     android:orientation="vertical">
 
                     <LinearLayout
+                        android:id="@+id/control_buttons"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="5dp"
+                        android:layout_marginBottom="25dp"
+                        android:orientation="horizontal"
+                        android:gravity="center">
+
+                        <ImageView
+                            android:id="@+id/play_btn"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:fontFamily="@font/poppins_semibold"
+                            android:gravity="center_horizontal"
+                            android:includeFontPadding="false"
+                            android:src="@drawable/vid_play"
+                            android:textColor="@color/leadme_white"
+                            android:textSize="12sp" />
+
+                        <ImageView
+                            android:id="@+id/pause_btn"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginStart="35dp"
+                            android:fontFamily="@font/poppins_semibold"
+                            android:gravity="center_horizontal"
+                            android:includeFontPadding="false"
+                            android:src="@drawable/vid_pause_highlight"
+                            android:textColor="@color/leadme_white"
+                            android:textSize="12sp" />
+
+                        <ImageView
+                            android:id="@+id/mute_btn"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginStart="35dp"
+                            android:fontFamily="@font/poppins_semibold"
+                            android:gravity="center_horizontal"
+                            android:includeFontPadding="false"
+                            android:src="@drawable/vid_mute"
+                            android:textColor="@color/leadme_white"
+                            android:textSize="12sp" />
+
+                        <ImageView
+                            android:id="@+id/unmute_btn"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginStart="35dp"
+                            android:fontFamily="@font/poppins_semibold"
+                            android:gravity="center_horizontal"
+                            android:includeFontPadding="false"
+                            android:src="@drawable/vid_unmute"
+                            android:textColor="@color/leadme_white"
+                            android:textSize="12sp" />
+                    </LinearLayout>
+
+                    <LinearLayout
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
@@ -157,31 +218,6 @@
                             android:thumb="@drawable/toggle_thumb"
                             android:track="@drawable/toggle_track" />
 
-                        <ImageView
-                            android:id="@+id/mute_btn"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:layout_marginStart="20dp"
-                            android:fontFamily="@font/poppins_semibold"
-                            android:gravity="center_horizontal"
-                            android:includeFontPadding="false"
-                            android:src="@drawable/vid_mute"
-                            android:textColor="@color/leadme_white"
-                            android:textSize="12sp" />
-
-                        <ImageView
-                            android:id="@+id/unmute_btn"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:layout_marginStart="20dp"
-                            android:fontFamily="@font/poppins_semibold"
-                            android:gravity="center_horizontal"
-                            android:includeFontPadding="false"
-                            android:src="@drawable/vid_unmute"
-                            android:textColor="@color/leadme_white"
-                            android:textSize="12sp" />
                     </LinearLayout>
 
                     <LinearLayout


### PR DESCRIPTION
Youtube ad tweaks - skipping double, single ads at beginning and middle. Returning as soon as video has ended. 

Embeded guide control update - play and pause buttons added for guide, initial play is done through tapping the youtube player, touch is then disabled and buttons are used instead. This works much for efficiently than the tap option. 

Ad waiting function added - guide cannot start a youtube video until all the students have finished watching any ads, syncs up devices and doesn't leave anyone on paused. In case of bug a teacher can reapply the play function to un pause any devices.

Still needs testing on multiple devices.