### PR TITLE
Connection and reconnection testing

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="949ae64c" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-02-13T22:57:37.807901200Z" />
+    <multipleDevicesSelectedInDropDown value="true" />
+    <runningDeviceTargetsSelectedWithDialog>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="949ae64c" />
+          </Key>
+        </deviceKey>
+      </Target>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="SERIAL_NUMBER" />
+            <value value="RF8M90B2MZP" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetsSelectedWithDialog>
+  </component>
+</project>

--- a/core/src/main/java/com/lumination/leadme/DispatchManager.java
+++ b/core/src/main/java/com/lumination/leadme/DispatchManager.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 public class DispatchManager {
     private final String TAG = "Dispatcher";
-    private LeadMeMain main;
+    private final LeadMeMain main;
     protected String[] launchAppOnFocus = null;
     String tagRepush;
     String packageNameRepush;
@@ -210,6 +210,7 @@ public class DispatchManager {
                 action.startsWith(LeadMeMain.PING_TAG) ||
                 action.startsWith(LeadMeMain.LAUNCH_SUCCESS) ||
                 action.startsWith(LeadMeMain.STUDENT_NO_XRAY) ||
+                action.startsWith(LeadMeMain.DISCONNECTION) ||
                 action.startsWith(LeadMeMain.NAME_REQUEST)) {
             main.getNearbyManager().sendToSelected(Payload.fromBytes(bytes), selectedPeerIDs);
         } else {
@@ -376,6 +377,9 @@ public class DispatchManager {
 
                     } else if(action.startsWith(LeadMeMain.AUTO_UNINSTALL)) {
                         dispatchAction.uninstallApplication(action);
+
+                    } else if (action.startsWith(LeadMeMain.DISCONNECTION)) {
+                        dispatchAction.disconnectLearner(action);
 
                     } else if (action.startsWith(LeadMeMain.LAUNCH_URL)) {
                         dispatchAction.launchURL(action);
@@ -887,6 +891,19 @@ public class DispatchManager {
             Collections.addAll(main.getLumiAppInstaller().appsToManage, appArray);
 
             main.getLumiAppInstaller().runUninstaller();
+        }
+
+        /**
+         * The guide is recieving a message that a learner has just abruptly disconnected.
+         * @param action A string of the incoming action, it contains the ID of the disconnecting
+         *               peer.
+         */
+        private void disconnectLearner(String action) {
+            String[] split = action.split(":"); //get the peer ID
+
+            //TODO disconnect this student
+            Log.e(TAG, split[1] + " has just disconnected");
+            main.getNearbyManager().networkAdapter.updateParent("Blah", Integer.parseInt(split[1]), "LOST");
         }
 
         /**

--- a/core/src/main/java/com/lumination/leadme/NearbyPeersManager.java
+++ b/core/src/main/java/com/lumination/leadme/NearbyPeersManager.java
@@ -32,6 +32,7 @@ public class NearbyPeersManager {
     boolean discovering;
 
     public String myName;
+    private int tryConnect = 0;
 
     /**
      * Constructor which initiates the networkAdapter class.
@@ -80,12 +81,12 @@ public class NearbyPeersManager {
         Log.d(TAG, "onBackPressed: deprecated");
     }
 
-    int tryConnect = 0;
     protected void connectToSelectedLeader() {
         String Name = selectedLeader.getDisplayName();
+
         if(manInfo == null) {
             ArrayList<NsdServiceInfo> discoveredLeaders = networkAdapter.discoveredLeaders;
-
+            Log.d(TAG, "Leaders array: " + discoveredLeaders.size());
             for (NsdServiceInfo info : discoveredLeaders) {
                 Log.d(TAG, "connectToSelectedLeader: " + info.getServiceName());
                 if (info.getServiceName().equals(Name + "#Teacher")) {
@@ -130,8 +131,8 @@ public class NearbyPeersManager {
             info.setPort(54321);
             info.setServiceName("Manual#Teacher");
             info.setServiceType("_http._tcp.");
-                    Log.d(TAG, "run: "+info);
-                    manInfo = info;
+            Log.d(TAG, "run: "+info);
+            manInfo = info;
             networkAdapter.discoveredLeaders.add(info);
             selectedLeader = new ConnectedPeer("Manual", IpAddress);
             main.runOnUiThread(this::connectToSelectedLeader);

--- a/core/src/main/java/com/lumination/leadme/XrayManager.java
+++ b/core/src/main/java/com/lumination/leadme/XrayManager.java
@@ -49,14 +49,9 @@ public class XrayManager {
 
     ScreenshotManager screenshotManager;
 
-//    String ipAddress;
-//    Intent screen_share_intent = null;
-//    private MediaProjectionManager projectionManager = null;
-
     public Bitmap response;
     Boolean monitorInProgress = false;
     ServerSocket serverSocket = null;
-    int screenshotRate = 200;
 
     private TextView xrayStudentSelectedView, xrayStudentDisplayNameView;
     private ImageView xrayStudentIcon, xrayScreenshotView;
@@ -75,8 +70,6 @@ public class XrayManager {
         //spinner to let the teachers know it is loading
         loadingPanel = xrayScreen.findViewById(R.id.xrayLoadingPanel);
     }
-
-//    boolean screenCapPermission = false;
 
     private void setupXrayView() {
         xrayStudentIcon = xrayScreen.findViewById(R.id.student_icon);
@@ -347,26 +340,6 @@ public class XrayManager {
         //xrayStudentSelectedView.invalidate();
     }
 
-//Old code
-//    public void startServer() {
-//        Log.w(TAG, "Starting server...");
-//        main.getPermissionsManager().waitingForPermission = true;
-//        if (!screenCapPermission) {
-//            projectionManager = (MediaProjectionManager) main.getSystemService(Context.MEDIA_PROJECTION_SERVICE);
-//
-//            //start service class
-//            screen_share_intent = new Intent(main.getApplicationContext(), ScreensharingService.class);
-//            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-//                main.startForegroundService(screen_share_intent);
-//            } else {
-//                main.startService(screen_share_intent);
-//            }
-//
-//            //start screen capturing
-//            main.startActivityForResult(projectionManager.createScreenCaptureIntent(), main.SCREEN_CAPTURE);
-//        }
-//    }
-
     private void imageRunnableFunction(String imgPeer) {
         Log.e(TAG, "Starting imageRunnable: " + serverSocket.isClosed() + ", " + serverSocket.isBound());
         Socket socket;
@@ -470,12 +443,16 @@ public class XrayManager {
         }
     }
 
+    public void removePeerFromMap(String peer) {
+        Log.d(TAG, "Peer removed: " + peer);
+        clientSocketThreads.remove(peer);
+        clientRecentScreenshots.remove(peer);
+    }
+
     public void resetClientMaps(String peer) {
         //Removing a single peer from the HashMaps
         if(peer != null) {
-            Log.d(TAG, "Peer removed: " + peer);
-            clientSocketThreads.remove(peer);
-            clientRecentScreenshots.remove(peer);
+            removePeerFromMap(peer);
         } else {
             Log.d(TAG, "Resetting hash maps");
 

--- a/core/src/main/res/layout/c__leader_main.xml
+++ b/core/src/main/res/layout/c__leader_main.xml
@@ -80,7 +80,7 @@
             android:paddingEnd="20dp"/>
     </LinearLayout>
 
-<!--Layout for after Updates have been enabled-->
+    <!--Layout for after Updates have been enabled-->
 <!--    <HorizontalScrollView-->
 <!--        android:layout_width="350dp"-->
 <!--        android:layout_height="wrap_content"-->
@@ -288,9 +288,10 @@
 <!--                app:layout_gravity="center_horizontal|top" />-->
 
 <!--        </LinearLayout>-->
-
 <!--    </HorizontalScrollView>-->
+    <!--End Layout for after Updates have been enabled-->
 
+    <!--Old title layout-->
     <LinearLayout
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
@@ -406,6 +407,7 @@
             app:layout_gravity="center_horizontal|top" />
 
     </LinearLayout>
+    <!--End Old title layout-->
 
 
     <RelativeLayout


### PR DESCRIPTION
Start discovery only implemented if not already discovering, was constantly being called for learners when moving pages. Causing connection issues as the leaders had not yet loaded again when trying to scrap data from discovered leaders.

Reconnection function added to network adapter to reconnect the learner to the guide in the event of a drop out, managed in background threads to not disturb the application.

Client ID management added for reconnecting or connecting students, this should fix any problems with the Xray manager as well.