### PR TITLE
Fix for the resolve 3 error

### DIFF
--- a/core/src/main/java/com/lumination/leadme/LeadMeMain.java
+++ b/core/src/main/java/com/lumination/leadme/LeadMeMain.java
@@ -2076,6 +2076,7 @@ public class LeadMeMain extends FragmentActivity implements Handler.Callback, Se
         leaderLearnerSwitcher.setDisplayedChild(SWITCH_LEADER_INDEX);
         leader_toggle.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.bg_active_right_leader, null));
         learner_toggle.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.bg_passive_left_white, null));
+        getNearbyManager().networkAdapter.stopDiscovery();
     }
 
     private void displayLearnerStartToggle() {


### PR DESCRIPTION
Issue with NSD manager resolver. 
Service discovery was not being stopped when a guide logged in. When a learner device tries to resolve multiple services it can result in a service busy error (error code 3). Meaning if multiple teachers are logged in only one may be visible.

Leaving a small time block between resolving each service allows enough time to clear the pipeline for the next.

*Removed unused code as well.