### PR TITLE
Changed minimum API level to 29

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    defaultMinSdkVersion = 24
+    defaultMinSdkVersion = 29
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.lumination.leadme"
-        minSdkVersion 24
+        minSdkVersion 29
         targetSdkVersion 30
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/core/src/main/java/com/lumination/leadme/services/FileTransferService.java
+++ b/core/src/main/java/com/lumination/leadme/services/FileTransferService.java
@@ -1,6 +1,5 @@
 package com.lumination.leadme.services;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -18,13 +17,11 @@ import com.lumination.leadme.R;
 import com.lumination.leadme.utilities.ClientTransferTask;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-@TargetApi(29)
 public class FileTransferService extends Service {
     private static final String TAG = "FileTransferService";
 

--- a/core/src/main/java/com/lumination/leadme/services/FirebaseService.java
+++ b/core/src/main/java/com/lumination/leadme/services/FirebaseService.java
@@ -1,6 +1,5 @@
 package com.lumination.leadme.services;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -9,18 +8,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.IBinder;
-import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
-import com.google.firebase.firestore.FirebaseFirestore;
 import com.lumination.leadme.R;
 
 /**
  * Create specifically to handle when an application crashes, sends a last message to firebase
  * to delete any records of the currently logged in user to stop duplicates occuring.
  */
-@TargetApi(29)
 public class FirebaseService extends Service {
     private static final String TAG = "FirebaseService";
     private static final String CHANNEL_ID = "firebase_communication";

--- a/core/src/main/java/com/lumination/leadme/services/NetworkService.java
+++ b/core/src/main/java/com/lumination/leadme/services/NetworkService.java
@@ -1,6 +1,5 @@
 package com.lumination.leadme.services;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -24,7 +23,6 @@ import java.util.HashMap;
 /**
  * Responsible for handling network connection between a leader and a learner.
  */
-@TargetApi(29)
 public class NetworkService extends Service {
     private static final String TAG = "NetworkService";
     private static final String CHANNEL_ID = "network_service";

--- a/core/src/main/java/com/lumination/leadme/services/ScreensharingService.java
+++ b/core/src/main/java/com/lumination/leadme/services/ScreensharingService.java
@@ -1,6 +1,5 @@
 package com.lumination.leadme.services;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
@@ -14,7 +13,6 @@ import androidx.core.app.NotificationCompat;
 
 import com.lumination.leadme.R;
 
-@TargetApi(29)
 public class ScreensharingService extends Service {
     private static final String CHANNEL_ID = "screen_capture";
     private static final String CHANNEL_NAME = "Screen_Capture";


### PR DESCRIPTION
Updated the minimum API level to 29, below this there are various functions throughout the code that rely on API 29 or above to function, found in NetworkService, FireTransferManager & FirebaseService.
- This may be a reason as to why some errors are occurring as phones have not been updated.