### PR TITLE
fix(AuthenticationManager): lock down Terms-Of-Use WebView (refs #99)

### DIFF
--- a/core/src/main/java/com/lumination/leadme/managers/AuthenticationManager.java
+++ b/core/src/main/java/com/lumination/leadme/managers/AuthenticationManager.java
@@ -9,7 +9,10 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -325,7 +328,40 @@ public class AuthenticationManager {
                 errorText.setVisibility(View.GONE);
                 hasScrolled = true;
                 WebView TOF = loginView.findViewById(R.id.tof_webview);
-                TOF.getSettings().setJavaScriptEnabled(true);
+                // CWE-749: harden the Terms-Of-Use WebView. JavaScript is
+                // required for the Google Drive PDF viewer to render, so we
+                // keep it on but lock down everything else: file:// access
+                // disabled, only the viewer's expected hosts are allowed to
+                // navigate, anything else is dropped.
+                WebSettings tofSettings = TOF.getSettings();
+                tofSettings.setJavaScriptEnabled(true);
+                tofSettings.setAllowFileAccess(false);
+                tofSettings.setAllowContentAccess(false);
+                tofSettings.setAllowFileAccessFromFileURLs(false);
+                tofSettings.setAllowUniversalAccessFromFileURLs(false);
+                tofSettings.setSavePassword(false);
+                TOF.setWebViewClient(new WebViewClient() {
+                    @Override
+                    public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                        Uri url = request.getUrl();
+                        String scheme = url.getScheme();
+                        if (scheme == null || !(scheme.equals("https") || scheme.equals("http"))) {
+                            return true;
+                        }
+                        String host = url.getHost();
+                        if (host == null) {
+                            return true;
+                        }
+                        // Allow only the Google Drive viewer's own redirect
+                        // chain and the source PDF host.
+                        return !(host.equals("docs.google.com")
+                                || host.equals("drive.google.com")
+                                || host.equals("www.google.com")
+                                || host.equals("accounts.google.com")
+                                || host.equals("github.com")
+                                || host.equals("raw.githubusercontent.com"));
+                    }
+                });
                 String pdf = "https://github.com/LuminationDev/public/raw/main/LeadMeEdu-TermsAndConditions.pdf";
                 TOF.loadUrl("https://drive.google.com/viewerng/viewer?embedded=true&url=" + pdf);
 


### PR DESCRIPTION
## Lock down the Terms-Of-Use WebView (refs #99)

### Scope

Issue #99 is the bulk Mend SAST report (816 findings across 18 CWE
categories). It is not addressable in a single PR. This PR delivers
one **real** CWE-749 fix scoped to the file the original draft was
already touching:
`core/src/main/java/com/lumination/leadme/managers/AuthenticationManager.java`.

### What is wrong today

The Terms-Of-Use case in `buildloginsignup` does this:

```java
WebView TOF = loginView.findViewById(R.id.tof_webview);
TOF.getSettings().setJavaScriptEnabled(true);
String pdf = "https://github.com/LuminationDev/public/raw/main/LeadMeEdu-TermsAndConditions.pdf";
TOF.loadUrl("https://drive.google.com/viewerng/viewer?embedded=true&url=" + pdf);
```

Three problems:

1. **No `WebViewClient`.** The viewer's redirect chain (Google Drive
   bounces through `docs.google.com`, `accounts.google.com`, etc.) is
   followed unconditionally. Any link the rendered PDF or a redirect
   chain pushes into the WebView is loaded without allow-listing.
2. **Platform-default file access.** On older API levels
   `setAllowFileAccessFromFileURLs` and
   `setAllowUniversalAccessFromFileURLs` default to `true`. Combined
   with JS enabled, a redirected page can read local app data via
   `fetch('file:///...')` / XHR.
3. **JS enabled + no host restriction** is exactly the configuration
   the CWE-749 SAST rule fires on.

### What this PR changes

* Wraps the WebView's settings into a `WebSettings` local and:
  * `setAllowFileAccess(false)`
  * `setAllowContentAccess(false)`
  * `setAllowFileAccessFromFileURLs(false)`
  * `setAllowUniversalAccessFromFileURLs(false)`
  * `setSavePassword(false)`
* Installs a minimal `WebViewClient` whose `shouldOverrideUrlLoading`
  returns `true` (i.e. drop the navigation) unless the destination is
  `https://`/`http://` to one of:
  * `docs.google.com`
  * `drive.google.com`
  * `www.google.com`
  * `accounts.google.com`
  * `github.com`
  * `raw.githubusercontent.com`

JavaScript stays on because the Google Drive viewer needs it to render.

### Out of scope

The other 815 findings in the Mend report are not addressed here and
remain tracked by #99.
